### PR TITLE
Console message fixes

### DIFF
--- a/R/install.R
+++ b/R/install.R
@@ -24,7 +24,6 @@ install_package <- function(filename, lib = .libPaths()[[1L]],
 #' directories, source tarballs or binary packages.
 #' @inheritParams install_binary
 #' @param num_workers Number of parallel workers to use
-#' @param progress show a progress bar of installation progress.
 #' @param plan The installation plan from `pkgdepends::remote`
 #' @param metadata for internal use only
 #' @param vignettes whether to (re)build the vignettes of the packages
@@ -35,9 +34,11 @@ install_package <- function(filename, lib = .libPaths()[[1L]],
 install_packages <- function(
   filenames, lib = .libPaths()[[1L]], plan = get_install_plan(filenames, lib),
   lock = getOption("install.lock", TRUE), metadata = NULL, vignettes = TRUE,
-  num_workers = 1, progress = interactive()) {
+  num_workers = 1) {
 
   start <- Sys.time()
+
+  progress <- is_verbose()
 
   bar_fmt <- if (isTRUE(progress)) {
     collapse(sep = " | ", c(

--- a/R/install.R
+++ b/R/install.R
@@ -258,8 +258,8 @@ new_install_packages_process <-  function(file, metadata, vignettes, lib,
     args = list(
       filenames = file, metadata = metadata, vignettes = vignettes,
       lib = lib, lock = lock, num_workers = 1,
-      crayon.enabled = getOption("crayon.enabled"),
-      crayon.colors = getOption("crayon.colors")),
+      crayon.enabled = crayon::has_color(),
+      crayon.colors = crayon::num_colors()),
 
     function(filenames, metadata, vignettes, lib, lock, num_workers,
              crayon.enabled, crayon.colors) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -39,7 +39,6 @@ warn <- function(msg, type = NULL, ..., .envir = parent.frame()) {
       ))
 }
 
-#' @importFrom rlang %||%
 `%!in%` <- function(x, y) {
   !x %in% y
 }
@@ -93,3 +92,8 @@ map_chr <- get("map_chr", asNamespace("rlang"))
 map_int <- get("map_int", asNamespace("rlang"))
 
 lengths <- function(x) vapply(x, length, integer(1))
+
+#' @importFrom rlang %||%
+is_verbose <- function() {
+  getOption("pkg.show_progress") %||% interactive()
+}

--- a/man/install_packages.Rd
+++ b/man/install_packages.Rd
@@ -6,8 +6,7 @@
 \usage{
 install_packages(filenames, lib = .libPaths()[[1L]],
   plan = get_install_plan(filenames, lib), lock = getOption("install.lock",
-  TRUE), metadata = NULL, vignettes = TRUE, num_workers = 1,
-  progress = interactive())
+  TRUE), metadata = NULL, vignettes = TRUE, num_workers = 1)
 }
 \arguments{
 \item{filenames}{filenames of packages to install. Can be source
@@ -26,8 +25,6 @@ compatibility with `utils::install.packages()`.}
 \item{vignettes}{whether to (re)build the vignettes of the packages}
 
 \item{num_workers}{Number of parallel workers to use}
-
-\item{progress}{show a progress bar of installation progress.}
 }
 \description{
 Install multiple local packages

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -37,7 +37,7 @@ describe("install_packages", {
   })
 
   withr::with_options(
-    list(pkg.progress.bar = FALSE),
+    list(pkg.show_progress = FALSE),
     expect_error_free(
       install_packages("foo_0.0.0.9000.tar.gz", lib = libpath))
   )

--- a/tests/testthat/test-metadata.R
+++ b/tests/testthat/test-metadata.R
@@ -48,7 +48,7 @@ test_that("install_packages metadata", {
   libpath <- create_temp_dir()
   on.exit(unlink(c(libpath, pkg), recursive = TRUE), add = TRUE)
 
-  withr::with_options(list(pkg.progress.bar = FALSE), {
+  withr::with_options(list(pkg.show_progress = FALSE), {
     plan <- get_install_plan(pkg, library = libpath)
     plan$metadata[[1]] <- c("Foo" = "Bar", "Foobar" = "baz")
     expect_error_free(install_packages(pkg, lib = libpath, plan = plan))


### PR DESCRIPTION
* Use the `pkg.show_progress` option to enable/disable progress bars, remove function argument. This is consistent with the other pkg* packages.
* Fix passing crayon options to workers. The options might not be set, so we need to pass the actual state.