### PR TITLE
Add username (r-lib) to devtools install

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Compared to `utils::install.packages()` it
 ## Installation
 
 ```r
-devtools::install_github("pkginstall")
+devtools::install_github("r-lib/pkginstall")
 ```
 
 ## Example


### PR DESCRIPTION
Because R yelled at me and it was terrifying…

```r
devtools::install_github("pkginstall")
#> Error in username %||% getOption("github.user") %||% stop("Unknown username.") : 
#> Unknown username.
```
Created on 2018-02-16 by the [reprex package](http://reprex.tidyverse.org) (v0.2.0).