### PR TITLE
Don't warn for loaded packages

### DIFF
--- a/R/install_binary.R
+++ b/R/install_binary.R
@@ -40,16 +40,6 @@ install_extracted_binary <- function(filename, lib_cache, pkg_cache, lib,
   add_metadata(pkg$path, metadata)
   pkg_name <- pkg$name
 
-  if (is_loaded(pkg_name)) {
-    loaded_from <- dirname(getNamespaceInfo(pkg_name, "path"))
-    if (normalizePath(loaded_from) == normalizePath(lib)) {
-      warn(type = "runtime_error",
-        "Package {pkg_name} is already loaded, installing may cause problems.
-         Use `pkgload::unload({pkg_name})` to unload it.",
-        package = pkg_name)
-    }
-  }
-
   lockfile <- lock_cache(lib_cache, pkg_name, getOption("install.lock"))
   on.exit(unlock(lockfile), add = TRUE)
 


### PR DESCRIPTION
A warning is sub-optimal, because it is only emitted after  the installation has happened. pkgman now
warns for all problematic packages at once, up front, before the installation actually starts.

See https://github.com/r-lib/pkgman/commit/e8d6b6c7a254a218738a4aa187ac1ce8950140dd