### PR TITLE
Tests with non-ascii library paths

### DIFF
--- a/tests/testthat/foo/R/foo.R
+++ b/tests/testthat/foo/R/foo.R
@@ -3,3 +3,7 @@
 foo <- function() {
   .Call(foo_)
 }
+
+.onUnload <- function(libpath) {
+  library.dynam.unload("foo", libpath)
+}

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -49,7 +49,7 @@ expect_error_free <- function(...) {
 }
 
 if (is_loaded("foo")) {
-  pkgload::unload("foo")
+  unloadNamespace("foo")
 }
 
 #' @importFrom callr r_process r_process_options

--- a/tests/testthat/test-paths.R
+++ b/tests/testthat/test-paths.R
@@ -1,0 +1,64 @@
+
+context("non-trivial paths")
+
+test_that("folders with potentially problematic characters", {
+
+  skip_on_cran()
+
+  tmp <- tempfile()
+  on.exit(tryCatch(unloadNamespace("foo"), error = identity), add = TRUE)
+  on.exit(unlink(tmp, recursive = TRUE), add = TRUE)
+  on.exit(environment(need_internal_tar)$internal <- NULL, add = TRUE)
+
+  pkg <- binary_test_package("foo_0.0.0.9000")
+
+  folders <- c(
+    "s p a c e s",
+    enc2native("\u00fa\u00e1\u00f6\u0151\u00e9"),
+    "s' p' a' c' e' s'"
+  )
+
+  skipped <- 0
+
+  for (f in folders) {
+    error <- FALSE
+    tryCatch(
+      {
+        if ("foo" %in% loadedNamespaces()) unloadNamespace("foo")
+        unlink(tmp, recursive = TRUE)
+        dir.create(tmp)
+        dir.create(file.path(tmp, f))
+        libdir <- dir(tmp)
+        libpath <- file.path(tmp, libdir)
+      },
+      warning = function(e) error <<- TRUE,
+      error = function(e) error <<- TRUE
+    )
+    if (error) { skipped <- skipped + 1; next }
+
+    ## Reset this
+    environment(need_internal_tar)$internal <- NULL
+
+    expect_error_free(install_binary(pkg, lib = libpath, quiet = TRUE))
+    expect_error_free(library("foo", lib.loc = libpath))
+    expect_equal(foo::foo(), NULL)
+    unloadNamespace("foo")
+
+    ## Make sure tar is internal
+    unlink(tmp, recursive = TRUE)
+    dir.create(tmp)
+    dir.create(libpath)
+    environment(need_internal_tar)$internal <- NULL
+    withr::with_envvar(c(TAR = NA),
+      withr::with_path("foobar", action = "replace", {
+        expect_error_free(install_binary(pkg, lib = libpath, quiet = TRUE))
+      })
+    )
+
+    expect_error_free(library("foo", lib.loc = libpath))
+    expect_equal(foo::foo(), NULL)
+    unloadNamespace("foo")
+  }
+
+  if (skipped) skip(paste(skipped, " path tests were skipped"))
+})


### PR DESCRIPTION
Closes #17, eventually.

Before merging, we need to make sure that we test this with the internal unzip and internal untar as well.

What other special characters do we need to test?