### PR TITLE
Use tmp dir in library to move the installed pkg

### DIFF
--- a/R/install_binary.R
+++ b/R/install_binary.R
@@ -64,6 +64,7 @@ install_extracted_binary <- function(filename, lib_cache, pkg_cache, lib,
     # the DLL open), then try to delete it, which may fail if another process
     # has the file open.
     move_to <- file.path(lib_cache, pkg_name)
+    dir.create(dirname(move_to), showWarnings = FALSE, recursive = TRUE)
     # In case there is a broken install here already
     unlink(move_to, recursive = TRUE, force = TRUE)
     ret <- file.rename(installed_path, move_to)

--- a/R/install_binary.R
+++ b/R/install_binary.R
@@ -63,7 +63,7 @@ install_extracted_binary <- function(filename, lib_cache, pkg_cache, lib,
     # First move the existing library (which still works even if a process has
     # the DLL open), then try to delete it, which may fail if another process
     # has the file open.
-    move_to <- file.path(create_temp_dir(), pkg_name)
+    move_to <- file.path(lib_cache, pkg_name)
     ret <- file.rename(installed_path, move_to)
     if (!ret) {
       abort(type = "filesystem",

--- a/R/install_binary.R
+++ b/R/install_binary.R
@@ -62,11 +62,17 @@ install_extracted_binary <- function(filename, lib_cache, pkg_cache, lib,
   if (file.exists(installed_path)) {
     # First move the existing library (which still works even if a process has
     # the DLL open), then try to delete it, which may fail if another process
-    # has the file open.
-    move_to <- file.path(lib_cache, pkg_name)
+    # has the file open. Some points:
+    # - the <lib_cache> / <pkg_name> directory might exist with the leftovers
+    #   of a previous installation, typically because the DLL file was/is
+    #   locked, so we could not delete it after the move.
+    # - so we create a random path component to avoid interference
+    # - we also unlink() the whole package-specific cache directory,
+    #   to avoid accumulating junk there. This is safe, well, if we are
+    #   locking, which is strongly suggested.
+    move_to <- file.path(lib_cache, pkg_name, basename(tempfile()))
+    unlink(dirname(move_to), recursive = TRUE, force = TRUE)
     dir.create(dirname(move_to), showWarnings = FALSE, recursive = TRUE)
-    # In case there is a broken install here already
-    unlink(move_to, recursive = TRUE, force = TRUE)
     ret <- file.rename(installed_path, move_to)
     if (!ret) {
       abort(type = "filesystem",

--- a/R/install_binary.R
+++ b/R/install_binary.R
@@ -64,6 +64,8 @@ install_extracted_binary <- function(filename, lib_cache, pkg_cache, lib,
     # the DLL open), then try to delete it, which may fail if another process
     # has the file open.
     move_to <- file.path(lib_cache, pkg_name)
+    # In case there is a broken install here already
+    unlink(move_to, recursive = TRUE, force = TRUE)
     ret <- file.rename(installed_path, move_to)
     if (!ret) {
       abort(type = "filesystem",


### PR DESCRIPTION
To handle the case when the library and the R
temporary directory are on different partitions,
because `file.rename()` fails in this case.

Closes #37 and
closes https://github.com/r-lib/pak/issues/112